### PR TITLE
Add docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ coverage
 .next
 backend/build
 backend/.cache
+db-data/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,12 @@
+FROM strapi/base:10
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+RUN npm run-script build
+
+CMD [ "npm", "run", "dev" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,21 +4,11 @@ services:
   backend:
     build: backend/
     command: npm run-script develop
-    environment:
-      - APP_NAME=eqx
-      - DATABASE_HOST=db
-      - DATABASE_PORT=5432
-      - DATABASE_CLIENT=postgres
-      - DATABASE_NAME=eqx
-      - DATABASE_USERNAME=postgres
-      - DATABASE_PASSWORD=postgres
-      - HOST=localhost
     ports:
       - 1337:1337
     volumes:
       - ./backend:/usr/src/app/eqx
-    depends_on:
-      - db
+      - sqlite3:/usr/src/app/eqx/.tmp/db.data
 
   frontend:
     build: frontend/
@@ -29,12 +19,5 @@ services:
       - /usr/src/app/node_modules
     working_dir: /usr/src/app
 
-  db:
-    image: postgres:11
-    environment:
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_USER=postgres
-      - POSTGRES_DB=eqx
-    volumes:
-      - ./db-data:/var/lib/postgresql/data
-
+volumes:
+  sqlite3:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+---
+version: '3'
+services:
+  backend:
+    build: backend/
+    command: npm run-script develop
+    environment:
+      - APP_NAME=eqx
+      - DATABASE_HOST=db
+      - DATABASE_PORT=5432
+      - DATABASE_CLIENT=postgres
+      - DATABASE_NAME=eqx
+      - DATABASE_USERNAME=postgres
+      - DATABASE_PASSWORD=postgres
+      - HOST=localhost
+    ports:
+      - 1337:1337
+    volumes:
+      - ./backend:/usr/src/app/eqx
+    depends_on:
+      - db
+
+  frontend:
+    build: frontend/
+    ports:
+      - 3000:3000
+    volumes:
+      - ./frontend:/usr/src/app
+      - /usr/src/app/node_modules
+    working_dir: /usr/src/app
+
+  db:
+    image: postgres:11
+    environment:
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=eqx
+    volumes:
+      - ./db-data:/var/lib/postgresql/data
+

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:10
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+RUN npm install
+RUN npm rebuild node-sass
+
+COPY . .
+
+RUN npm run-script build
+
+CMD [ "npm", "run", "dev" ]


### PR DESCRIPTION
This adds docker-compose for local development. 

Since we're using sqlite3, the docker-compose will persist this data to `backend/.tmp/db.data` on your machine.

This involves: 
- A Dockerfile for the backend
- A Dockerfile for the frontend
- A docker-compose file to build the Dockerfiles and spin everything up!

You can test this out by following the instructions in the README.
