### PR TITLE
Add string around localhost

### DIFF
--- a/backend/config/environments/production/server.json
+++ b/backend/config/environments/production/server.json
@@ -1,5 +1,5 @@
 {
-  "host": "${process.env.APP_HOST || localhost}",
+  "host": "${process.env.APP_HOST || 'localhost'}",
   "port": "${process.env.PORT || 1337}",
   "production": true,
   "proxy": {


### PR DESCRIPTION
Sorry, seems I forgot to make localhost a string!

Question though: why does Strapi use the `production` env config when developing? 